### PR TITLE
Change runner from self-hosted to ubuntu-22.04

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -8,7 +8,7 @@ on:
 jobs:
     unit-test:
         container: cuaesd/aesd-autotest:24-unit-test
-        runs-on: self-hosted
+        runs-on: ubuntu-22.04
         steps:
           - uses: actions/checkout@v2
           - name: Checkout submodules
@@ -17,7 +17,7 @@ jobs:
             run: ./unit-test.sh
     full-test:
         container: cuaesd/aesd-autotest:24-assignment1
-        runs-on: self-hosted
+        runs-on: ubuntu-22.04
         steps:
           - uses: actions/checkout@v2
           - name: Checkout submodules


### PR DESCRIPTION
Removes the necessity of using a self-hosted runner relying on github hosted runners.
It is compliant with instructions reported in the course.

Closes #61 